### PR TITLE
Add default omit option property to prevent undefined error from

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -7,7 +7,8 @@ var args = minimist(process.argv.slice(2));
 
 diff({
   files: args["_"] || [],
-  visual: args["v"] || args["visual"] || false
+  visual: args["v"] || args["visual"] || false,
+  omit: args["o"] || args["omit"] || []
 })
 .done(function(diff) {
   if (options.visual) {


### PR DESCRIPTION
I get "Error: Cannot read property 'indexOf' of undefined" due to the ref of _this.options.omit.indexOf property line index.js:52. Adding a default value for the omit options property resolved it.

btw... thanks for the util
