### PR TITLE
Add option to output actual differences in css format

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool makes it simple to see if the compiled output of a stylus file matches
 
 ## Command Line
 
-The command line interface takes 2 paths to css/styl/scss files as well as an options `-v` or `--visual` argument to print the diff. The return value of the invokation with be `true` or `false`.
++The command line interface takes 2 paths to css/styl/scss files as well as an options `-v` or `--visual` argument to print the diff or `-u` or `--updates` argument to print updated rules. The return value of the invokation with be `true` or `false`.
 
 * `$ npm install css-diff`
 * `$ node_modules/.bin/css-diff path/to/file.styl path/to/file2.css -v`
@@ -27,10 +27,10 @@ require("css-diff")({
   omit: [ //optional ability to omit rule types
     "comment"
   ]
-  visual: true //defaults to false
+  updates: true //defaults to false
 }).then(function(diff) {
-  console.log(diff.visual);
-  console.log(diff.different);
+  // prints actuall css difference between those two files
+  console.log(diff.updates);
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -16,11 +16,152 @@ module.exports = function(options) {
 }
 
 function handleError(e) {
-  process.stderr.write(("Error: "+e.message+"\n").red.inverse);
+  process.stderr.write(e);
   process.exit(1);
 }
 
 function generateDiff(diff) {
+  var _this = this;
+  if (_this.options.updates) {
+      return generateUpdatesDiff(diff);
+  }
+  return generateOrigDiff(diff);
+}
+
+function generateUpdatesDiff(diff) {
+  var openSelector = false;
+  var selectorCount = 0;
+
+  var markedCss = diff.map(function(part) {
+    var output = "";
+    var mode = "";
+
+    if(part.removed) {
+      return output;
+    }
+
+    if(part.value.indexOf('"selectors"') !== -1 && part.value.indexOf('"declarations"') !== -1) {
+      mode = 'selector-declaration';
+
+      if(part.value.lastIndexOf('"selectors"') > part.value.lastIndexOf('"declarations"')) {
+        mode = 'selector';
+      }
+      else {
+        mode = 'declaration';
+      }
+    }
+    else if(part.value.indexOf('"selectors"') !== -1) {
+      mode = 'selector';
+    }
+    else if(part.value.indexOf('"declarations"') !== -1) {
+      mode = 'declaration';
+    }
+    else {
+      mode = 'property';
+    }
+
+    if(openSelector) {
+      if(selectorCount > 0) {
+        output += ", ";
+      }
+    }
+
+    if(mode == 'selector-declaration') {
+      openSelector = false;
+      selectorCount = 0;
+
+      output += part.value;
+    }
+    else if(mode == 'selector') {
+      openSelector = true;
+      selectorCount = 0;
+
+      output += part.value;
+    }
+    else if(mode == 'declaration') {
+      openSelector = false;
+      selectorCount = 0;
+
+      output += part.value;
+    }
+    else if(mode == 'property') {
+      // selector
+      if(openSelector) {
+        part.value = JSON.stringify({
+          type: "selector",
+          selector: part.value,
+          changed: part.added
+        });
+
+        output += part.value;
+
+        selectorCount += 1;
+      }
+
+      // property
+      else {
+        output += part.value;
+
+        if(part.added) {
+          output += '\n, "changed": "true"';
+        }
+      }
+    }
+    else {
+      output += part.value;
+    }
+
+    return output;
+  });
+
+  markedCss = markedCss.join('');
+
+  var changedRules = JSON.parse(markedCss)
+  .filter(function(o) {
+    return o.type === "rule";
+  })
+  .reduce(function(prev, rule) {
+    var declarations = rule.declarations.reduce(function(prev, declaration) {
+      if (declaration.changed) prev.push(declaration);
+      return prev;
+    }, []);
+    if (declarations.length) prev.push({
+      type: rule.type,
+      selectors: rule.selectors,
+      declarations: declarations
+    });
+    return prev;
+  }, []);
+
+
+  var updates = changedRules.reduce(function(prev, rule) {
+    rule.selectors.forEach(function(selector) {
+      var item = selector.selector || selector;
+
+      item = item.trim();
+      if(item.lastIndexOf(',') === (item.length - 1)) item = item.substr(0, item.length - 1);
+      if(item.lastIndexOf('"') === (item.length - 1)) item = item.substr(0, item.length - 1);
+      if(item.indexOf('"') === 0) item = item.substr(1);
+
+      prev += item;
+
+      prev += ' {';
+      rule.declarations.forEach(function(declaration) {
+        prev += declaration.property + ':' + declaration.value + ';';
+      });
+      prev += '}\n';
+    });
+
+    return prev;
+  }, "");
+
+
+  return {
+    updates: updates
+  };
+}
+
+function generateOrigDiff(diff) {
   var different   = false;
   var visual      = diff.reduce(function(prev, part) {
     var color = part.added ? "green" : part.removed ? "red" : "grey";


### PR DESCRIPTION
By passing the following option:

``` js
require("css-diff")({
  files: [
    "path/to/file1.css",
    "path/to/file2.scss"
  ],
  omit: [ //optional ability to omit rule types
    "comment"
  ]
  updates: true 
}).then(function(diff) {
  console.log(diff.updates);
})
```

you will receive the actual css-differences semantically per selector in css format.
